### PR TITLE
benchmark_report.json + timestamp

### DIFF
--- a/benchmark_report.py
+++ b/benchmark_report.py
@@ -15,7 +15,7 @@ class BenchmarkReport:
         load_dotenv('.env')
         self.benchmark_name = benchmark_name
         self.retry_limit = retry_limit
-        self.date = datetime.now().strftime('%Y-%m-%d')
+        self.date = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         self.run_at = datetime.now(timezone.utc).isoformat()
         self.timestamp_ms = datetime.now().timestamp()
 


### PR DESCRIPTION
adding timestamp to the name to avoid overriding results every time 
<img width="731" alt="Screenshot 2025-01-29 at 19 21 56" src="https://github.com/user-attachments/assets/a28387f8-8677-4d46-9175-8f34936a24bb" />
